### PR TITLE
Fix links.ejs

### DIFF
--- a/layout/_widget/links.ejs
+++ b/layout/_widget/links.ejs
@@ -3,7 +3,7 @@
 	<h4><%= __('links') %></h4>
 	<ul class="blogroll list-unstyled">
 	<% for (var i in theme.links){ %>
-		<li><i class="<%- theme.links[i].icon %>"></i><a href="<%- theme.links[i].url %>" title="<%- theme.links[i].intro %>" target="_blank"]);"><%= theme.links[i].title %></a></li>
+		<li><i class="<%- theme.links[i].icon %>"></i><a href="<%- theme.links[i].url %>" title="<%- theme.links[i].intro %>" target="_blank"><%= theme.links[i].title %></a></li>
 	<% } %>
 	</ul>
 </div>


### PR DESCRIPTION
Fix parsing errors:

```
ERROR {
  err: Error: Parse Error: <a href="https://github.com/blackshow/hexo-theme-freemind.386" title="Freemind.386's Github reposi
tory." target="_blank"]);">Freemind.386</a></li>
```


```

    at new HTMLParser (/hexo-blog/node_modules/html-minifier-terser/src/htmlparser.js:244:13)
    at minify (/hexo-blog/node_modules/html-minifier-terser/src/htmlminifier.js:993:3)
    at exports.minify (/hexo-blog/node_modules/html-minifier-terser/src/htmlminifier.js:1354:16)
    at Hexo.OptimizeHTML (/hexo-blog/node_modules/hexo-all-minifier/lib/optimizeHTML.js:24:14)
    at Hexo.tryCatcher (/hexo-blog/node_modules/bluebird/js/release/util.js:16:23)
    at Hexo.<anonymous> (/hexo-blog/node_modules/bluebird/js/release/method.js:15:34)
    at /hexo-blog/node_modules/hexo/lib/extend/filter.js:67:52
    at tryCatcher (/hexo-blog/node_modules/bluebird/js/release/util.js:16:23)
    at Object.gotValue (/hexo-blog/node_modules/bluebird/js/release/reduce.js:166:18)
    at Object.gotAccum (/hexo-blog/node_modules/bluebird/js/release/reduce.js:155:25)
    at Object.tryCatcher (/hexo-blog/node_modules/bluebird/js/release/util.js:16:23)
    at Promise._settlePromiseFromHandler (/hexo-blog/node_modules/bluebird/js/release/promise.js:547:31)
    at Promise._settlePromise (/hexo-blog/node_modules/bluebird/js/release/promise.js:604:18)
    at Promise._settlePromise0 (/hexo-blog/node_modules/bluebird/js/release/promise.js:649:10)
    at Promise._settlePromises (/hexo-blog/node_modules/bluebird/js/release/promise.js:729:18)
    at _drainQueueStep (/hexo-blog/node_modules/bluebird/js/release/async.js:93:12)
    at _drainQueue (/hexo-blog/node_modules/bluebird/js/release/async.js:86:9)
    at Async._drainQueues (/hexo-blog/node_modules/bluebird/js/release/async.js:102:5)
    at Immediate.Async.drainQueues [as _onImmediate] (/hexo-blog/node_modules/bluebird/js/release/async.js:15:14)
    at processImmediate (internal/timers.js:461:21)
```