### PR TITLE
解决非首页的文章feature图片显示失败的问题

### DIFF
--- a/layout/_partial/post/entry.ejs
+++ b/layout/_partial/post/entry.ejs
@@ -2,7 +2,7 @@
   <div class="row">
 	<% if (item.feature ) { %>
            <% if (config.post_asset_folder){ %>
-  	      <div class="thumbnail"><a href="<%- config.root %><%= item.path %>"><img src="<%= item.path %><%= item.feature %>" alt="<%= item.title %>"  class="nofancybox"></a>
+  	      <div class="thumbnail"><a href="<%- config.root %><%= item.path %>"><img src="<%- config.root %><%= item.path %><%= item.feature %>" alt="<%= item.title %>"  class="nofancybox"></a>
            <% } else { %>
               <div class="thumbnail"><a href="<%- config.root %><%= item.path %>"><img src="<%= item.feature %>" alt="<%= item.title %>"  class="nofancybox"></a>
            <% } %>


### PR DESCRIPTION
非首页的文章feature图片路径，会在图片路径前加上当前文章的页码，如图所示的`/page/3`，致使图片读取失败.

![非首页的文章图片加载失败](https://user-images.githubusercontent.com/25722877/232763723-9dda85fe-2d38-4b5c-b5b2-4268b0c9d054.png)

正常图片地址如下图所示

![非首页的文章图片加载失败2](https://user-images.githubusercontent.com/25722877/232764198-456428bf-c428-47cb-8bb5-162efd7745e0.png)

解决后feature图片正常，效果如下

![非首页的文章图片加载失败3](https://user-images.githubusercontent.com/25722877/232764601-554ea9d2-fc1e-4696-b00a-f1a3fabde6c4.png)

